### PR TITLE
コンテナにserverspecは不要そうなのでGemfileを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /myapp
 COPY Gemfile /myapp/Gemfile
 COPY Gemfile.lock /myapp/Gemfile.lock
 
-RUN bundle install
+RUN bundle install --without local
 
 COPY . /myapp
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,6 @@ gem 'unicorn'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
-  # RSpec tests for your servers configured by CFEngine, Puppet, Chef, Ansible, Itamae or anything else even by hand
-  gem 'serverspec'
 end
 
 group :development do
@@ -48,6 +46,11 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+group :local do
+  # RSpec tests for your servers configured by CFEngine, Puppet, Chef, Ansible, Itamae or anything else even by hand
+  gem 'serverspec'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
- コンテナにserverspecは不要の様なのでインストールグループを新設
- 併せてDockerfileも修正
- Dockerイメージのビルド所要時間の短縮も見込む

```
$ time docker-compose build
# 改修前
docker-compose build  0.80s user 0.20s system 0% cpu 6:12.78 total
# 改修後
docker-compose build  0.79s user 0.21s system 0% cpu 5:55.96 total
```
